### PR TITLE
Added the ability to track the BDD steps executed during a test

### DIFF
--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Addition/AddTwoNumbers.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Addition/AddTwoNumbers.cs
@@ -1,9 +1,15 @@
-﻿namespace Xunit.Gherkin.Quick.ProjectConsumer.Addition
+﻿using System;
+using Xunit.Abstractions;
+
+namespace Xunit.Gherkin.Quick.ProjectConsumer.Addition
 {
     [FeatureFile("./Addition/AddTwoNumbers.feature")]
     public sealed class AddTwoNumbers : Feature
     {
         private readonly Calculator _calculator = new Calculator();
+
+        public AddTwoNumbers(ITestOutputHelper output) : base(output)
+        {}
 
         [Given(@"I chose (\d+) as first number")]
         public void I_chose_first_number(int firstNumber)

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/App.config
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.diagnosticMessages" value="true"/>
+  </appSettings>
+</configuration>

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/source/Xunit.Gherkin.Quick/Feature.cs
+++ b/source/Xunit.Gherkin.Quick/Feature.cs
@@ -13,14 +13,14 @@ namespace Xunit.Gherkin.Quick
     public abstract class Feature
     {
         /// <summary>Allows you to log extra data to the result of the test.</summary>
-        protected ITestOutputHelper Output { get; set; }
+        protected ITestOutputHelper Output { get; }
 
-        [Obsolete("To recieve step-level output from your tests, use the constructor passing an ITestOutputHelper")]
+        /// <summary>Create a new Feature.</summary>
         protected Feature() {}
 
         /// <summary>Create a new Feature.</summary>
         /// <param name="output">
-        /// Allows you to log extra data to the result of the test. Xunit will provide you with an implementation
+        /// Allows you to log extra data to the result of the test. Xunit will provide you with an instance
         /// in your constructor which you can pass straight through e.g. public MyFeatureClass(ITestOutputHelper output) : base(output)
         /// </param>
         protected Feature(ITestOutputHelper output) => Output = output;


### PR DESCRIPTION
While this works, there are a couple of improvements that would make it a bit nicer:
- At the moment you have to add the <add key="xunit.diagnosticMessages" value="true"/> to the test project's app.config manually. Ideally it would be set when the nuget package is installed, but I haven't figured out how to do that with .net standard packages just yet. If that doesn't work we might be able to set it from code at the test discovery phase
- I've set the empty version of the Feature class constructor to obsolete, to try and push people to the version taking the ITestOutputHelper. The empty constructor could then be removed in the next major version? The alternative is allowing both and dealing with it in documentation. I'm happy to remove the [Obsolete] attribute if you want ;)