### PR TITLE
Pickles doc integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ Unit test name in this case will be "AddTwoNumbers :: Add two numbers", which is
 
 If the feature has multiple scenarios, add them to the same feature file. They will show up as additional tests in the test explorer. And they will need additional methods in the same feature class for execution.
 
+## Integrating Test Results With PicklesDoc
+
+Test results may be integrated with the excellent [PicklesDoc project](http://www.picklesdoc.com/). Run your tests with
+
+```
+dotnet xunit -xml MyResultsFile.xml
+```
+
+This file is an xunit2 formatted file, which you can integrate with picklesdoc in a variety of ways - see the pickles documentation.
 
 ## See Also
 

--- a/source/Xunit.Gherkin.Quick/Scenario/ScenarioDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/Scenario/ScenarioDiscoverer.cs
@@ -27,7 +27,7 @@ namespace Xunit.Gherkin.Quick
 
             foreach (var scenario in gherkinDocument.Feature.Children)
             {
-                yield return new ScenarioXUnitTestCase(_messageSink, testMethod, $"{gherkinDocument.Feature.Name} :: {scenario.Name}", new object[] { scenario.Name });
+                yield return new ScenarioXUnitTestCase(_messageSink, testMethod, gherkinDocument.Feature.Name, scenario.Name, new object[] { scenario.Name });
             }
         }
 

--- a/source/Xunit.Gherkin.Quick/Scenario/ScenarioXUnitTestCase.cs
+++ b/source/Xunit.Gherkin.Quick/Scenario/ScenarioXUnitTestCase.cs
@@ -19,7 +19,7 @@ namespace Xunit.Gherkin.Quick
         {
             DisplayName = $"{featureName} :: {scenarioName}";
 
-            // These traits allow support for the excelent picklesdoc results visualizer
+            // These traits allow support for the picklesdoc results visualizer (http://www.picklesdoc.com/)
             Traits = new Dictionary<string, List<string>>
             {
                 {  "FeatureTitle", new List<string> { featureName } },

--- a/source/Xunit.Gherkin.Quick/Scenario/ScenarioXUnitTestCase.cs
+++ b/source/Xunit.Gherkin.Quick/Scenario/ScenarioXUnitTestCase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
@@ -13,10 +14,17 @@ namespace Xunit.Gherkin.Quick
         {
         }
 
-        public ScenarioXUnitTestCase(IMessageSink messageSink, ITestMethod testMethod, string scenarioName, object[] testMethodArguments = null)
+        public ScenarioXUnitTestCase(IMessageSink messageSink, ITestMethod testMethod, string featureName, string scenarioName, object[] testMethodArguments = null)
             : base(messageSink, TestMethodDisplay.Method, testMethod, testMethodArguments)
         {
-            DisplayName = scenarioName;
+            DisplayName = $"{featureName} :: {scenarioName}";
+
+            // These traits allow support for the excelent picklesdoc results visualizer
+            Traits = new Dictionary<string, List<string>>
+            {
+                {  "FeatureTitle", new List<string> { featureName } },
+                {  "Description", new List<string> { scenarioName } }
+            };
         }
 
         public override async Task<RunSummary> RunAsync(

--- a/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
+++ b/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
@@ -15,7 +15,7 @@
     <PackageTags>BDD, Gherkin, Xunit, Testing, Behavior Driven Development</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/ttutisani/Xunit.Gherkin.Quick</RepositoryUrl>
-    <Version>1.1.5</Version>
+    <Version>1.1.0</Version>
     <PackageReleaseNotes>https://github.com/ttutisani/Xunit.Gherkin.Quick/blob/master/versions/1.1.0.md</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
+++ b/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
@@ -15,7 +15,7 @@
     <PackageTags>BDD, Gherkin, Xunit, Testing, Behavior Driven Development</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/ttutisani/Xunit.Gherkin.Quick</RepositoryUrl>
-    <Version>1.1.0</Version>
+    <Version>1.1.5</Version>
     <PackageReleaseNotes>https://github.com/ttutisani/Xunit.Gherkin.Quick/blob/master/versions/1.1.0.md</PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
- Added support for picklesdoc by including the FeatureTitle and Description traits on each test
- Included some brief help text in the readme

This mimics the output of SpecFlow, and also gives us searching via trait in the test explorer window for free.

Also, apologies for disappearing at the end of my last PR - I had some time away ill and TBH totally forgot about it!

