### PR TITLE
Added scenario outline example support into DataTable parameters

### DIFF
--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
@@ -1,0 +1,31 @@
+﻿using Gherkin.Ast;
+using System.Linq;
+
+namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
+{
+    [FeatureFile("./Placeholders/Placeholders.feature")]
+    public sealed class Placeholder : Feature
+    {
+        private DataTable _data;
+
+        [Given("I have supplied a DataTable with")]
+        public void Given_I_Have_Supplied_DataTable(DataTable data)
+        {
+            _data = data;
+        }
+
+        [When("I execute a scenario outline")]
+        public void When_I_Execute_A_Scenario_Outline()
+        {
+        }
+
+        [Then(@"the DataTables MealExtra column should contain (\w+)")]
+        public void Then_The_DataTables_MealExtra_Column_Should_Contain(string fruit)
+        {
+            Assert.NotNull(_data);
+            var dataRow = _data.Rows.Skip(1).FirstOrDefault();
+            Assert.NotNull(dataRow);
+            Assert.Equal(fruit, dataRow.Cells.FirstOrDefault()?.Value);
+        }
+    }
+}

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
@@ -1,0 +1,12 @@
+﻿Feature: Placeholders Feature
+  
+Scenario Outline: Placeholders in DataTables are replaced
+    Given I have supplied a DataTable with
+        | MealExtra   |
+        | <Fruit>     |
+    When I execute a scenario outline
+    Then the DataTables MealExtra column should contain <Fruit>
+    Examples:
+        | Fruit |
+        | Apple |
+        | Pear  |

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -46,6 +46,9 @@
     <None Update="GivenWhenThenTests\SimpleParameterTypes.feature">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Placeholders\Placeholders.feature">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="StarNotation\StarNotation.feature">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
I've added the support for Scenario Outline examples in DataTable arguments. Its supported by a unit test and an example scenario. I've tried to keep the level of the test similar to the other things in that file, but I'm happy to split it out a little if you think it is testing too much in one.

I've not changed the documentation etc as I think its already expected behaviour but again happy to add anything you think would be useful.

Thanks!