### PR TITLE
Upgrade framework and package dependencies

### DIFF
--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
@@ -16,16 +16,16 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
 
         int IntegerValue;
 
-        [When(@"I choose the integer value {int}")]
+        [When(@"I pass the integer value {int} using cucumber expression")]
         public void SetInteger(int i)
         {
             IntegerValue = i;
         }
 
-        [Then(@"the triple value is {int}")]
-        public void CheckTriple(int t)
+        [Then(@"the received integer value is ([+-]?\d+) using regex")]
+        public void CheckInteger(int t)
         {
-            Assert.Equal(t, IntegerValue * 3);
+            Assert.Equal(t, IntegerValue);
         }
 
         #endregion
@@ -35,16 +35,16 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
 
         float FloatValue;
 
-        [When(@"I choose the float value {float}")]
+        [When(@"I pass the float value {float} using cucumber expression")]
         public void SetFloat(float f)
         {
             FloatValue = f;
         }
 
-        [Then(@"10.75 more is {float}")]
-        public void AddToFloat(float expected)
+        [Then(@"the received float value is ([+-]?([0-9]*[.])?[0-9]+) using regex")]
+        public void CheckFloat(float expected)
         {
-            Assert.Equal(expected, FloatValue + 10.75);
+            Assert.Equal(expected, FloatValue);
         }
 
         #endregion
@@ -52,25 +52,18 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
 
         #region Word
 
-        string FirstWord;
-        string SecondWord;
+        string WordValue;
 
-        [Given(@"the first word is {word}")]
-        public void SetFirstWord(string word)
+        [When(@"I pass the word {word} using cucumber expression")]
+        public void SetWord(string word)
         {
-            FirstWord = word;
+            WordValue = word;
         }
 
-        [When(@"I choose the second word (\w+)")]
-        public void SetSecondWord(string word)
+        [Then(@"the received word is (\w+) using regex")]
+        public void CheckWord(string expectedOutput)
         {
-            SecondWord = word;
-        }
-
-        [Then(@"the concatenation of them is (\w+)")]
-        public void IsConcatenated(string expectedOutput)
-        {
-            Assert.Equal(expectedOutput, FirstWord + SecondWord);
+            Assert.Equal(expectedOutput, WordValue);
         }
 
         #endregion
@@ -80,16 +73,16 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
 
         string StringValue;
 
-        [When(@"I choose the string {string}")]
+        [When(@"I pass the string {string} using cucumber expression")]
         public void SetString(string s)
         {
             StringValue = s;
         }
 
-        [Then(@"the lower case string is {string}")]
-        public void IsLowerCase(string expected)
+        [Then(@"the received string is ""([^""]*)"" using regex")]
+        public void CheckString(string expected)
         {
-            Assert.Equal(expected, StringValue.ToLower());
+            Assert.Equal(expected, StringValue);
         }
 
         #endregion

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
@@ -1,0 +1,115 @@
+﻿using System.Threading;
+
+namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
+{
+    [FeatureFile("./CucumberExpressions/PassParameters.feature")]
+    public class PassParameters : Feature
+    {
+        public PassParameters()
+        {
+            // Needed to ensure floats always use "." for decimal points.
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+        }
+
+
+        #region Integer
+
+        int IntegerValue;
+
+        [When(@"I choose the integer value {int}")]
+        public void SetInteger(int i)
+        {
+            IntegerValue = i;
+        }
+
+        [Then(@"the triple value is {int}")]
+        public void CheckTriple(int t)
+        {
+            Assert.Equal(t, IntegerValue * 3);
+        }
+
+        #endregion
+
+
+        #region Float
+
+        float FloatValue;
+
+        [When(@"I choose the float value {float}")]
+        public void SetFloat(float f)
+        {
+            FloatValue = f;
+        }
+
+        [Then(@"10.75 more is {float}")]
+        public void AddToFloat(float expected)
+        {
+            Assert.Equal(expected, FloatValue + 10.75);
+        }
+
+        #endregion
+
+
+        #region Word
+
+        string FirstWord;
+        string SecondWord;
+
+        [Given(@"the first word is {word}")]
+        public void SetFirstWord(string word)
+        {
+            FirstWord = word;
+        }
+
+        [When(@"I choose the second word (\w+)")]
+        public void SetSecondWord(string word)
+        {
+            SecondWord = word;
+        }
+
+        [Then(@"the concatenation of them is (\w+)")]
+        public void IsConcatenated(string expectedOutput)
+        {
+            Assert.Equal(expectedOutput, FirstWord + SecondWord);
+        }
+
+        #endregion
+
+
+        #region String
+
+        string StringValue;
+
+        [When(@"I choose the string {string}")]
+        public void SetString(string s)
+        {
+            StringValue = s;
+        }
+
+        [Then(@"the lower case string is {string}")]
+        public void IsLowerCase(string expected)
+        {
+            Assert.Equal(expected, StringValue.ToLower());
+        }
+
+        #endregion
+
+
+        #region Any/wildcard/anonymous
+
+        [When(@"I say {}")]
+        public void SetWildcardString(string s)
+        {
+            StringValue = s;
+        }
+
+        [Then(@"it is the same as {string}")]
+        public void IsRepeated(string s)
+        {
+            Assert.Equal(s, StringValue);
+        }
+
+
+        #endregion
+    }
+}

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.cs
@@ -85,6 +85,12 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
             Assert.Equal(expected, StringValue);
         }
 
+        [Then(@"the received string is '([^']*)' using single quotes regex")]
+        public void CheckStringSingleQuote(string expected)
+        {
+            Assert.Equal(expected, StringValue);
+        }
+
         #endregion
 
 
@@ -96,7 +102,7 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.CucumberExpressions
             StringValue = s;
         }
 
-        [Then(@"it is the same as {string}")]
+        [Then(@"it is the same as ""([^""]*)""")]
         public void IsRepeated(string s)
         {
             Assert.Equal(s, StringValue);

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
@@ -4,49 +4,54 @@
 
 
 Scenario: Pass positive integer to step function
-  When I choose the integer value 10
-  Then the triple value is 30
+  When I pass the integer value 10 using cucumber expression
+  Then the received integer value is 10 using regex
 
 
 Scenario: Pass negative integer to step function
-  When I choose the integer value -22
-  Then the triple value is -66
+  When I pass the integer value -22 using cucumber expression
+  Then the received integer value is -22 using regex
 
 
 Scenario: Pass integer zero to step function
-  When I choose the integer value 0
-  Then the triple value is 0
+  When I pass the integer value 0 using cucumber expression
+  Then the received integer value is 0 using regex
 
 
 Scenario: Pass positive float to step function
-  When I choose the float value 10.25
-  Then 10.75 more is 21.00
+  When I pass the float value 10.25 using cucumber expression
+  Then the received float value is 10.25 using regex
 
 
 Scenario: Pass negative float to step function
-  When I choose the float value -20.25
-  Then 10.75 more is -9.50
+  When I pass the float value -20.25 using cucumber expression
+  Then the received float value is -20.25 using regex
 
 
 Scenario: Pass float zero to step function
-  When I choose the float value 0.0
-  Then 10.75 more is 10.75
+  When I pass the float value 0 using cucumber expression
+  Then the received float value is 0 using regex
+
+
+Scenario: Pass float zero dot zero to step function
+  When I pass the float value 0.0 using cucumber expression
+  Then the received float value is 0.0 using regex
 
 
 Scenario: Pass word to step function
-  Given the first word is Max
-  When I choose the second word Motor
-  Then the concatenation of them is MaxMotor
+  When I pass the word Max using cucumber expression
+  Then the received word is Max using regex
 
 
 Scenario: Pass string to step function
-  When I choose the string "A and B and C"
-  Then the lower case string is "a and b and c"
+  When I pass the string "11 and A B C" using cucumber expression
+  Then the received string is "11 and A B C" using regex
 
 
 Scenario: Pass empty string to step function
-  When I choose the string ""
-  Then the lower case string is ""
+  When I pass the string "" using cucumber expression
+  Then the received string is "" using regex
+
 
 Scenario: Pass anything to step function
   When I say Quasimodo the Grand

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
@@ -43,13 +43,33 @@ Scenario: Pass word to step function
   Then the received word is Max using regex
 
 
-Scenario: Pass string to step function
+Scenario: Pass double quoted string to step function
   When I pass the string "11 and A B C" using cucumber expression
   Then the received string is "11 and A B C" using regex
 
 
+Scenario: Pass double quoted string with single quotes to step function
+  When I pass the string "11 and 'A' or 'B' or 'C'" using cucumber expression
+  Then the received string is "11 and 'A' or 'B' or 'C'" using regex
+
+
 Scenario: Pass empty string to step function
   When I pass the string "" using cucumber expression
+  Then the received string is "" using regex
+
+
+Scenario: Pass single quoted string to step function
+  When I pass the string '11 and A B C' using cucumber expression
+  Then the received string is "11 and A B C" using regex
+
+
+Scenario: Pass single quoted string with double quotes to step function
+  When I pass the string '11 and "A" and "B" and "C"' using cucumber expression
+  Then the received string is '11 and "A" and "B" and "C"' using single quotes regex
+
+
+Scenario: Pass single quoted empty string to step function
+  When I pass the string '' using cucumber expression
   Then the received string is "" using regex
 
 

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/CucumberExpressions/PassParameters.feature
@@ -1,0 +1,53 @@
+﻿Feature: pass parameters
+  In order to simplify use of regex
+  I want to use cucumber expressions in feature steps
+
+
+Scenario: Pass positive integer to step function
+  When I choose the integer value 10
+  Then the triple value is 30
+
+
+Scenario: Pass negative integer to step function
+  When I choose the integer value -22
+  Then the triple value is -66
+
+
+Scenario: Pass integer zero to step function
+  When I choose the integer value 0
+  Then the triple value is 0
+
+
+Scenario: Pass positive float to step function
+  When I choose the float value 10.25
+  Then 10.75 more is 21.00
+
+
+Scenario: Pass negative float to step function
+  When I choose the float value -20.25
+  Then 10.75 more is -9.50
+
+
+Scenario: Pass float zero to step function
+  When I choose the float value 0.0
+  Then 10.75 more is 10.75
+
+
+Scenario: Pass word to step function
+  Given the first word is Max
+  When I choose the second word Motor
+  Then the concatenation of them is MaxMotor
+
+
+Scenario: Pass string to step function
+  When I choose the string "A and B and C"
+  Then the lower case string is "a and b and c"
+
+
+Scenario: Pass empty string to step function
+  When I choose the string ""
+  Then the lower case string is ""
+
+Scenario: Pass anything to step function
+  When I say Quasimodo the Grand
+  Then it is the same as "Quasimodo the Grand"

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -22,6 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="CucumberExpressions\PassParameters.feature">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ReuseStepsAcrossFeatures\Concatenation.feature">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,9 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/source/Xunit.Gherkin.Quick.UnitTests/StepMethodInfoTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/StepMethodInfoTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests
             Assert.Single(sut.ScenarioStepPatterns);
 
             Assert.Equal(PatternKind.When, sut.ScenarioStepPatterns[0].Kind);
-            Assert.Equal(FeatureForCtorTest.WhenStepText, sut.ScenarioStepPatterns[0].Pattern);
+            Assert.Equal(FeatureForCtorTest.WhenStepText, sut.ScenarioStepPatterns[0].OriginalPattern);
         }
 
         private sealed class FeatureForCtorTest : Feature
@@ -348,7 +348,7 @@ in it";
 
                 Assert.NotNull(thePattern);
                 Assert.Equal(patternKind, thePattern.Kind);
-                Assert.Equal(pattern, thePattern.Pattern);
+                Assert.Equal(pattern, thePattern.OriginalPattern);
             }
         }
 
@@ -431,7 +431,7 @@ in it";
             //assert.
             Assert.NotNull(match);
             Assert.Equal(PatternKind.When, match.Kind);
-            Assert.Equal("this matches", match.Pattern);
+            Assert.Equal("this matches", match.OriginalPattern);
         }
 
         [Fact]

--- a/source/Xunit.Gherkin.Quick.UnitTests/StepMethodTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/StepMethodTests.cs
@@ -55,7 +55,7 @@ namespace UnitTests
             //assert.
             Assert.NotNull(sut);
             Assert.Equal(stepMethodInfo.ScenarioStepPatterns[1].Kind, sut.Kind);
-            Assert.Equal(stepMethodInfo.ScenarioStepPatterns[1].Pattern, sut.Pattern);
+            Assert.Equal(stepMethodInfo.ScenarioStepPatterns[1].OriginalPattern, sut.Pattern);
             Assert.Equal("something 123 else", sut.StepText);
         }
 

--- a/source/Xunit.Gherkin.Quick.UnitTests/Xunit.Gherkin.Quick.UnitTests.csproj
+++ b/source/Xunit.Gherkin.Quick.UnitTests/Xunit.Gherkin.Quick.UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
@@ -34,10 +34,10 @@ namespace Xunit.Gherkin.Quick
 
         private static string ConvertSpecialPatternsToRegex(string pattern)
         {
-            string p = pattern.Replace("{word}", @"(\w+)");
-            p = p.Replace("{int}", @"([+-]?\d+)");
+            string p = pattern.Replace("{int}", @"([+-]?\d+)");
             p = p.Replace("{float}", @"([+-]?([0-9]*[.])?[0-9]+)");
-            p = p.Replace("{string}", @"""([^""]*)""");
+            p = p.Replace("{word}", @"(\w+)");
+            p = p.Replace("{string}", @"(?:""|')([^\1]*)(?:""|')");
             p = p.Replace("{}", @"(.*)");
             return p;
         }

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
@@ -7,7 +7,17 @@ namespace Xunit.Gherkin.Quick
     internal sealed class ScenarioStepPattern
     {
         private readonly string _pattern;
+
+        /// <summary>
+        /// Original pattern as supplied from step attributes.
+        /// </summary>
         public string Pattern { get { return _pattern; } }
+
+        private readonly string _regexPattern;
+        /// <summary>
+        /// Original pattern where cucumber specific patterns (such as "{word}") have been replaced with regex patterns.
+        /// </summary>
+        public string RegexPattern { get { return _regexPattern; } }
 
         public PatternKind Kind { get; }
 
@@ -16,7 +26,18 @@ namespace Xunit.Gherkin.Quick
             _pattern = !string.IsNullOrWhiteSpace(pattern) 
                 ? pattern 
                 : throw new ArgumentNullException(nameof(pattern));
+            _regexPattern = ConvertSpecialPatternsToRegex(_pattern);
             Kind = stepMethodKind;
+        }
+
+        private string ConvertSpecialPatternsToRegex(string pattern)
+        {
+            string p = pattern.Replace("{word}", @"(\w+)");
+            p = p.Replace("{int}", @"([+-]?\d+)");
+            p = p.Replace("{float}", @"([+-]?([0-9]*[.])?[0-9]+)");
+            p = p.Replace("{string}", @"""([^""]*)""");
+            p = p.Replace("{}", @"(.*)");
+            return p;
         }
 
         public static List<ScenarioStepPattern> ListFromStepAttributes(IEnumerable<BaseStepDefinitionAttribute> baseStepDefinitionAttributes)

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
@@ -6,12 +6,12 @@ namespace Xunit.Gherkin.Quick
 {
     internal sealed class ScenarioStepPattern
     {
-        private readonly string _pattern;
+        private readonly string _originalPattern;
 
         /// <summary>
         /// Original pattern as supplied from step attributes.
         /// </summary>
-        public string Pattern { get { return _pattern; } }
+        public string OriginalPattern { get { return _originalPattern; } }
 
         private readonly string _regexPattern;
         /// <summary>
@@ -21,16 +21,18 @@ namespace Xunit.Gherkin.Quick
 
         public PatternKind Kind { get; }
 
-        public ScenarioStepPattern(string pattern, PatternKind stepMethodKind)
+        public ScenarioStepPattern(string pattern, string regexPattern, PatternKind stepMethodKind)
         {
-            _pattern = !string.IsNullOrWhiteSpace(pattern) 
+            _originalPattern = !string.IsNullOrWhiteSpace(pattern) 
                 ? pattern 
                 : throw new ArgumentNullException(nameof(pattern));
-            _regexPattern = ConvertSpecialPatternsToRegex(_pattern);
+            _regexPattern = !string.IsNullOrWhiteSpace(regexPattern)
+                ? regexPattern
+                : throw new ArgumentNullException(nameof(regexPattern));
             Kind = stepMethodKind;
         }
 
-        private string ConvertSpecialPatternsToRegex(string pattern)
+        private static string ConvertSpecialPatternsToRegex(string pattern)
         {
             string p = pattern.Replace("{word}", @"(\w+)");
             p = p.Replace("{int}", @"([+-]?\d+)");
@@ -44,7 +46,8 @@ namespace Xunit.Gherkin.Quick
         {
             return baseStepDefinitionAttributes.Select(attribute => 
                 new ScenarioStepPattern(
-                    attribute.Pattern, 
+                    attribute.Pattern,
+                    ConvertSpecialPatternsToRegex(attribute.Pattern),
                     PatternKindExtensions.ToPatternKind(attribute)))
                 .ToList();
         }

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethod.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethod.cs
@@ -36,7 +36,7 @@ namespace Xunit.Gherkin.Quick
 
             var stepMethodInfoClone = stepMethodInfo.Clone();
             stepMethodInfoClone.DigestScenarioStepValues(gherkinScenarioStep);
-            return new StepMethod(stepMethodInfoClone, matchingPattern.Kind, matchingPattern.Pattern, gherkinScenarioStep.Text);
+            return new StepMethod(stepMethodInfoClone, matchingPattern.Kind, matchingPattern.OriginalPattern, gherkinScenarioStep.Text);
         }
 
         public async Task ExecuteAsync()

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
@@ -92,7 +92,7 @@ namespace Xunit.Gherkin.Quick
             if (matchingPattern == null)
                 throw new InvalidOperationException($"This step (`{_methodInfoWrapper.GetMethodName()}`) cannot handle scenario step `{gherkinScenarioStep.Keyword.Trim()} {gherkinStepText}`.");
 
-            var argumentValuesFromStep = Regex.Match(gherkinStepText, matchingPattern.Pattern).Groups.Cast<Group>()
+            var argumentValuesFromStep = Regex.Match(gherkinStepText, matchingPattern.RegexPattern).Groups.Cast<Group>()
                 .Skip(1)
                 .Select(g => g.Value)
                 .ToArray();
@@ -114,7 +114,7 @@ namespace Xunit.Gherkin.Quick
                 if (!pattern.Kind.Matches(gherkinScenarioStep.Keyword.Trim()))
                     continue;
 
-                var match = Regex.Match(gherkinStepText, pattern.Pattern);
+                var match = Regex.Match(gherkinStepText, pattern.RegexPattern);
                 if (!match.Success || !match.Value.Equals(gherkinStepText))
                     continue;
 

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioXUnitTestCase.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioXUnitTestCase.cs
@@ -30,7 +30,8 @@ namespace Xunit.Gherkin.Quick
             
             : base(
                   messageSink, 
-                  TestMethodDisplay.Method, 
+                  TestMethodDisplay.Method,
+                  TestMethodDisplayOptions.None,
                   testMethod, 
                   testMethodArguments)
         {

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioXUnitTestCase.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioXUnitTestCase.cs
@@ -31,7 +31,6 @@ namespace Xunit.Gherkin.Quick
             : base(
                   messageSink, 
                   TestMethodDisplay.Method,
-                  TestMethodDisplayOptions.None,
                   testMethod, 
                   testMethodArguments)
         {


### PR DESCRIPTION
I continue to have issues compiling and running the tests in "Xunit.Gherkin.Quick.ProjectConsumer" and "Xunit.Gherkin.Quick.UnitTests". Upgrading to newer versions of "Microsoft.NET.Test.Sdk" and "xunit.runner.visualstudio" fixed it for me. Please consider upgrading the main repository.