### PR TITLE
Update Gherkin and add ability to work with multiple languages

### DIFF
--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/GivenWhenThenTests/InAnotherLanguage.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/GivenWhenThenTests/InAnotherLanguage.cs
@@ -1,0 +1,64 @@
+﻿namespace Xunit.Gherkin.Quick.ProjectConsumer
+{
+    [FeatureFile("./GivenWhenThenTests/InAnotherLanguage.feature")]
+    public sealed class InAnotherLanguage : Feature
+    {
+        private int _order = 0;
+
+
+
+        [Given(@"Monster tekst voor Stel")]
+        public void Sample_text_for_Given()
+        {
+            Assert.Equal(0, _order++);
+        }
+
+        [And(@"Monster tekst voor En na Stel")]
+        public void Sample_text_for_And_after_Given()
+        {
+            Assert.Equal(1, _order++);
+        }
+
+        [But(@"Monster tekst voor Maar na Stel")]
+        public void Sample_text_for_But_after_Given()
+        {
+            Assert.Equal(2, _order++);
+        }
+
+        [When(@"Monster tekst voor Als")]
+        public void Sample_text_for_When()
+        {
+            Assert.Equal(3, _order++);
+        }
+
+        [And(@"Monster tekst voor En na Als")]
+        public void Sample_text_for_And_after_When()
+        {
+            Assert.Equal(4, _order++);
+        }
+
+        [But(@"Monster tekst voor Maar na Als")]
+        public void Sample_text_for_But_after_When()
+        {
+            Assert.Equal(5, _order++);
+        }
+
+        [Then(@"Monster tekst voor Dan")]
+        public void Sample_text_for_Then()
+        {
+            Assert.Equal(6, _order++);
+        }
+
+        [And(@"Monster tekst voor En na Dan")]
+        public void Sample_text_for_And_after_Then()
+        {
+            Assert.Equal(7, _order++);
+        }
+
+        [But(@"Monster tekst voor Maar na Dan")]
+        public void Sample_text_for_But_after_Then()
+        {
+            Assert.Equal(8, _order++);
+        }
+    }
+}

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/GivenWhenThenTests/InAnotherLanguage.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/GivenWhenThenTests/InAnotherLanguage.feature
@@ -1,0 +1,42 @@
+﻿# language: nl
+
+#
+# Feature: Given When Then
+#	In order to use Given When Then and other attributes
+#	As a Gherkin enthusiast
+#	I want to ensure they map to methods
+#
+# In order to validate if the language attribute works I translated this 
+# "Feature" to dutch as it is the only other language I know. Maybe the Emoji 
+# (em) language is a better test case as not all developers understand dutch 
+# but everybody understand unicode glyphs.
+#
+
+Functionaliteit: Stel Als Dan
+	Om "Stel", "Als", "Dan" en andrere attributen te gebruiken
+	Als een Gherkin gebruiker
+	Wil ik valideren dat deze een relatie hebben tot de correcte methode
+
+	Scenario: Valideer de volgorde van de stappen
+		Stel Monster tekst voor Stel
+		En Monster tekst voor En na Stel
+		Maar Monster tekst voor Maar na Stel
+		Als Monster tekst voor Als
+		En Monster tekst voor En na Als
+		Maar Monster tekst voor Maar na Als
+		Dan Monster tekst voor Dan
+		En Monster tekst voor En na Dan
+		Maar Monster tekst voor Maar na Dan
+
+#
+# Scenario: Ensure order of steps
+#	Given Sample text for Given
+#	And Sample text for And after Given
+#	But Sample text for But after Given
+#	When Sample text for When
+#	And Sample text for And after When
+#	But Sample text for But after When
+#	Then Sample text for Then
+#	And Sample text for And after Then
+#	But Sample text for But after Then
+#

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -25,6 +25,9 @@
     <None Update="CucumberExpressions\PassParameters.feature">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="GivenWhenThenTests\InAnotherLanguage.feature">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ReuseStepsAcrossFeatures\Concatenation.feature">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Xunit.Gherkin.Quick.UnitTests/FeatureClassTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/FeatureClassTests.cs
@@ -100,7 +100,7 @@ namespace UnitTests
                 new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
-                        null,
+                        "Scenario",
                         scenario,
                         null,
                         steps.Select(s =>
@@ -332,7 +332,7 @@ namespace UnitTests
             var scenario = sut.ExtractScenario(CreateGherkinDocument("scenario 123", new string[]
             {
                 "Given something else"
-            }).Feature.Children.OfType<Gherkin.Ast.Scenario>().First());
+            }).Feature.Scenarios().First());
 
             //assert.
             Assert.NotNull(scenario);

--- a/source/Xunit.Gherkin.Quick.UnitTests/FeatureClassTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/FeatureClassTests.cs
@@ -95,7 +95,7 @@ namespace UnitTests
             string[] backgroundSteps = null)
         {
 
-            var definitions = new List<global::Gherkin.Ast.ScenarioDefinition>
+            var definitions = new List<global::Gherkin.Ast.Scenario>
             {
                 new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
@@ -111,27 +111,28 @@ namespace UnitTests
                                 s.Substring(0, spaceIndex).Trim(),
                                 s.Substring(spaceIndex).Trim(),
                                 stepArgument);
-                        }).ToArray())
+                        }).ToArray(),
+                        Array.Empty<global::Gherkin.Ast.Examples>())
             };
 
-            if(backgroundSteps != null)
-            {
-                definitions.Add(
-                    new Gherkin.Ast.Background(
-                        null,
-                        null,
-                        "background",
-                        null,
-                        backgroundSteps.Select(s =>
-                        {
-                            var spaceIndex = s.IndexOf(' ');
-                            return new Gherkin.Ast.Step(
-                                null,
-                                s.Substring(0, spaceIndex).Trim(),
-                                s.Substring(spaceIndex).Trim(),
-                                stepArgument);
-                        }).ToArray()));
-            }
+            //if(backgroundSteps != null)
+            //{
+            //    definitions.Add(
+            //        new Gherkin.Ast.Background(
+            //            null,
+            //            null,
+            //            "background",
+            //            null,
+            //            backgroundSteps.Select(s =>
+            //            {
+            //                var spaceIndex = s.IndexOf(' ');
+            //                return new Gherkin.Ast.Step(
+            //                    null,
+            //                    s.Substring(0, spaceIndex).Trim(),
+            //                    s.Substring(spaceIndex).Trim(),
+            //                    stepArgument);
+            //            }).ToArray()));
+            //}
 
             return new Gherkin.Ast.GherkinDocument(
                 new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, definitions.ToArray()),

--- a/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
@@ -96,7 +96,7 @@ namespace UnitTests
             Gherkin.Ast.StepArgument stepArgument = null)
         {
             return new Gherkin.Ast.GherkinDocument(
-                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
                 {
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
@@ -104,7 +104,8 @@ namespace UnitTests
                         null,
                         scenario,
                         null,
-                        new Gherkin.Ast.Step[]{ })
+                        new Gherkin.Ast.Step[]{ }
+                        , System.Array.Empty<global::Gherkin.Ast.Examples>())
                 }),
                 new Gherkin.Ast.Comment[0]);
         }
@@ -112,14 +113,14 @@ namespace UnitTests
         private static Gherkin.Ast.GherkinDocument CreateGherkinDocumentWithBackground()
         {
             return new Gherkin.Ast.GherkinDocument(
-                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Background(
-                        null,
-                        null,
-                        null,
-                        null,
-                        new Gherkin.Ast.Step[]{ })
+                    //new Gherkin.Ast.Background(
+                    //    null,
+                    //    null,
+                    //    null,
+                    //    null,
+                    //    new Gherkin.Ast.Step[]{ })
                 }),
                 new Gherkin.Ast.Comment[0]);
         }
@@ -129,9 +130,9 @@ namespace UnitTests
             Gherkin.Ast.StepArgument stepArgument = null)
         {
             return new Gherkin.Ast.GherkinDocument(
-                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(
+                    new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
                         null,

--- a/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
@@ -101,7 +101,7 @@ namespace UnitTests
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
-                        null,
+                        "Scenario",
                         scenario,
                         null,
                         new Gherkin.Ast.Step[]{ }
@@ -135,7 +135,7 @@ namespace UnitTests
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
-                        null,
+                        "Scenario Outline",
                         scenario,
                         null,
                         new Gherkin.Ast.Step[]{ },

--- a/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/FeatureFileTests.cs
@@ -113,14 +113,14 @@ namespace UnitTests
         private static Gherkin.Ast.GherkinDocument CreateGherkinDocumentWithBackground()
         {
             return new Gherkin.Ast.GherkinDocument(
-                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
+                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Background[]
                 {
-                    //new Gherkin.Ast.Background(
-                    //    null,
-                    //    null,
-                    //    null,
-                    //    null,
-                    //    new Gherkin.Ast.Step[]{ })
+                    new Gherkin.Ast.Background(
+                        null,
+                        null,
+                        null,
+                        null,
+                        new Gherkin.Ast.Step[]{ })
                 }),
                 new Gherkin.Ast.Comment[0]);
         }

--- a/source/Xunit.Gherkin.Quick.UnitTests/GherkinFeatureTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/GherkinFeatureTests.cs
@@ -53,7 +53,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[] 
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
+                    new Gherkin.Ast.Scenario(scenarioTags, null, "Scenario", scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -98,10 +98,10 @@ namespace UnitTests
             var scenarioName = "scenario name 123";
 
             var feature = new Gherkin.Ast.Feature(
-                featureTags, null, null, null, null, null,
+                featureTags, null, null, "Feature", null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
+                    new Gherkin.Ast.Scenario(scenarioTags, null, "Scenario", scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -134,7 +134,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
+                    new Gherkin.Ast.Scenario(scenarioTags, null, "Scenario", scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -167,7 +167,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
+                    new Gherkin.Ast.Scenario(scenarioTags, null, "Scenario", scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -236,7 +236,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, "Scenario Outline", scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -295,10 +295,10 @@ namespace UnitTests
             var examplesName = "examples name 123";
 
             var feature = new Gherkin.Ast.Feature(
-                featureTags, null, null, null, null, null,
+                featureTags, null, null, "Feature", null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, "Scenario Outline", scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -344,7 +344,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, "Scenario Outline", scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -390,7 +390,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, "Scenario Outline", scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -436,7 +436,7 @@ namespace UnitTests
                 featureTags, null, null, null, null, null,
                 new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, "Scenario Outline", scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)

--- a/source/Xunit.Gherkin.Quick.UnitTests/GherkinFeatureTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/GherkinFeatureTests.cs
@@ -51,9 +51,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[] 
+                new Gherkin.Ast.Scenario[] 
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null)
+                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -99,9 +99,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null)
+                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -132,9 +132,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null)
+                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -165,9 +165,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null)
+                    new Gherkin.Ast.Scenario(scenarioTags, null, null, scenarioName, null, null, System.Array.Empty<global::Gherkin.Ast.Examples>())
                 });
 
             //act.
@@ -234,9 +234,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -296,9 +296,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -342,9 +342,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -388,9 +388,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)
@@ -434,9 +434,9 @@ namespace UnitTests
 
             var feature = new Gherkin.Ast.Feature(
                 featureTags, null, null, null, null, null,
-                new Gherkin.Ast.ScenarioDefinition[]
+                new Gherkin.Ast.Scenario[]
                 {
-                    new Gherkin.Ast.ScenarioOutline(outlineTags, null, null, scenarioOutlineName, null, null,
+                    new Gherkin.Ast.Scenario(outlineTags, null, null, scenarioOutlineName, null, null,
                     new Gherkin.Ast.Examples[]
                     {
                         new Gherkin.Ast.Examples(examplesTags, null, null, examplesName, null, null, null)

--- a/source/Xunit.Gherkin.Quick.UnitTests/GherkinScenarioDefinitionTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/GherkinScenarioDefinitionTests.cs
@@ -40,7 +40,7 @@ namespace UnitTests
             var location = new Gherkin.Ast.Location(1, 1);
             var steps = new Gherkin.Ast.Step[] { new Gherkin.Ast.Step(null, null, "step", null) };
 
-            return new Gherkin.Ast.Scenario(tags, location, "keyword", "name", "description", steps);            
+            return new Gherkin.Ast.Scenario(tags, location, "keyword", "name", "description", steps, System.Array.Empty<global::Gherkin.Ast.Examples>());            
         }
     }
 }

--- a/source/Xunit.Gherkin.Quick.UnitTests/GherkinScenarioOutlineTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/GherkinScenarioOutlineTests.cs
@@ -17,7 +17,7 @@ namespace UnitTests
             )
         {
             //arrange.
-            var sut = new Gherkin.Ast.ScenarioOutline(
+            var sut = new Gherkin.Ast.Scenario(
                 null,
                 null,
                 null,
@@ -47,7 +47,7 @@ namespace UnitTests
         public void ApplyExampleRow_Digests_Row_Values_Into_Scenario()
         {
             //arrange.
-            var sut = new Gherkin.Ast.ScenarioOutline(
+            var sut = new Gherkin.Ast.Scenario(
                 null,
                 null,
                 null,
@@ -115,7 +115,7 @@ namespace UnitTests
         public void ApplyExampleRow_Digests_Row_Values_Into_Scenario_With_Multiple_Placeholders_Per_Step()
         {
             //arrange.
-            var sut = new Gherkin.Ast.ScenarioOutline(
+            var sut = new Gherkin.Ast.Scenario(
                 null,
                 null,
                 null,
@@ -181,7 +181,7 @@ namespace UnitTests
         public void ApplyExampleRow_Digests_Row_Values_Into_Scenario_With_DataTable_In_Step()
         {
             //arrange.
-            var sut = new Gherkin.Ast.ScenarioOutline(
+            var sut = new Gherkin.Ast.Scenario(
                 null,
                 null,
                 null,

--- a/source/Xunit.Gherkin.Quick.UnitTests/Helpers/GherkinFeatureBuilder.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/Helpers/GherkinFeatureBuilder.cs
@@ -7,11 +7,11 @@ namespace UnitTests
 {
     public class GherkinFeatureBuilder
     {
-        private List<ScenarioDefinition> _definitions;
+        private List<StepsContainer> _definitions;
 
         public GherkinFeatureBuilder()
         {
-            _definitions = new List<ScenarioDefinition>();
+            _definitions = new List<StepsContainer>();
         }
 
         public GherkinFeatureBuilder WithBackground(Action<GherkinStepBuilder> buildSteps)
@@ -31,7 +31,7 @@ namespace UnitTests
         {
             var stepBuilder = new GherkinStepBuilder();
             buildSteps(stepBuilder);
-            _definitions.Add(new Scenario(tags, null, null, name, null, stepBuilder.Steps));
+            _definitions.Add(new Scenario(tags, null, null, name, null, stepBuilder.Steps, Array.Empty<Examples>()));
             return this;
         }
 
@@ -43,7 +43,7 @@ namespace UnitTests
             var examplesBuilder = new ExamplesBuilder();
             buildExamples(examplesBuilder);
 
-            _definitions.Add(new ScenarioOutline(new Tag[0], null, null, name, null, stepBuilder.Steps, examplesBuilder.Examples));
+            _definitions.Add(new global::Gherkin.Ast.Scenario(new Tag[0], null, null, name, null, stepBuilder.Steps, examplesBuilder.Examples));
             return this;
         }
 

--- a/source/Xunit.Gherkin.Quick.UnitTests/Helpers/GherkinFeatureBuilder.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/Helpers/GherkinFeatureBuilder.cs
@@ -31,7 +31,7 @@ namespace UnitTests
         {
             var stepBuilder = new GherkinStepBuilder();
             buildSteps(stepBuilder);
-            _definitions.Add(new Scenario(tags, null, null, name, null, stepBuilder.Steps, Array.Empty<Examples>()));
+            _definitions.Add(new Scenario(tags, null, "Scenario", name, null, stepBuilder.Steps, Array.Empty<Examples>()));
             return this;
         }
 
@@ -43,7 +43,7 @@ namespace UnitTests
             var examplesBuilder = new ExamplesBuilder();
             buildExamples(examplesBuilder);
 
-            _definitions.Add(new global::Gherkin.Ast.Scenario(new Tag[0], null, null, name, null, stepBuilder.Steps, examplesBuilder.Examples));
+            _definitions.Add(new global::Gherkin.Ast.Scenario(new Tag[0], null, "Scenario Outline", name, null, stepBuilder.Steps, examplesBuilder.Examples));
             return this;
         }
 

--- a/source/Xunit.Gherkin.Quick.UnitTests/ScenarioExecutorTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/ScenarioExecutorTests.cs
@@ -110,7 +110,7 @@ namespace UnitTests
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0], 
                         null, 
-                        null, 
+                        "Scenario", 
                         scenario, 
                         null, 
                         steps.Select(s => 

--- a/source/Xunit.Gherkin.Quick.UnitTests/ScenarioExecutorTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/ScenarioExecutorTests.cs
@@ -105,7 +105,7 @@ namespace UnitTests
             Gherkin.Ast.StepArgument stepArgument = null)
         {
             return new Gherkin.Ast.GherkinDocument(
-                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[] 
+                new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[] 
                 {
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0], 
@@ -121,7 +121,8 @@ namespace UnitTests
                                 s.Substring(0, spaceIndex).Trim(), 
                                 s.Substring(spaceIndex).Trim(), 
                                 stepArgument);
-                        }).ToArray())
+                        }).ToArray()
+                        , System.Array.Empty<global::Gherkin.Ast.Examples>())
                 }),
                 new Gherkin.Ast.Comment[0]);
         }

--- a/source/Xunit.Gherkin.Quick.UnitTests/ScenarioOutlineExecutorTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/ScenarioOutlineExecutorTests.cs
@@ -493,9 +493,9 @@ namespace UnitTests
                 Gherkin.Ast.StepArgument stepArgument = null)
             {
                 return new Gherkin.Ast.GherkinDocument(
-                    new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[]
+                    new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
                     {
-                    new Gherkin.Ast.ScenarioOutline(
+                    new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
                         null,
@@ -637,9 +637,9 @@ namespace UnitTests
                 Gherkin.Ast.StepArgument stepArgument = null)
             {
                 return new Gherkin.Ast.GherkinDocument(
-                    new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.ScenarioDefinition[]
+                    new Gherkin.Ast.Feature(new Gherkin.Ast.Tag[0], null, null, null, null, null, new Gherkin.Ast.Scenario[]
                     {
-                    new Gherkin.Ast.ScenarioOutline(
+                    new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
                         null,

--- a/source/Xunit.Gherkin.Quick.UnitTests/ScenarioOutlineExecutorTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/ScenarioOutlineExecutorTests.cs
@@ -498,7 +498,7 @@ namespace UnitTests
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
-                        null,
+                        "Scenario Outline",
                         outlineName,
                         null,
                         new Gherkin.Ast.Step[]
@@ -642,7 +642,7 @@ namespace UnitTests
                     new Gherkin.Ast.Scenario(
                         new Gherkin.Ast.Tag[0],
                         null,
-                        null,
+                        "Scenario Outline",
                         outlineName,
                         null,
                         new Gherkin.Ast.Step[]

--- a/source/Xunit.Gherkin.Quick.UnitTests/StepMethodInfoTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/StepMethodInfoTests.cs
@@ -28,7 +28,7 @@ namespace UnitTests
             Assert.NotNull(sut.ScenarioStepPatterns);
             Assert.Single(sut.ScenarioStepPatterns);
 
-            Assert.Equal(PatternKind.When, sut.ScenarioStepPatterns[0].Kind);
+            Assert.Equal(GherkinDialect.KeywordFor.When, sut.ScenarioStepPatterns[0].Kind);
             Assert.Equal(FeatureForCtorTest.WhenStepText, sut.ScenarioStepPatterns[0].OriginalPattern);
         }
 
@@ -331,18 +331,18 @@ in it";
             Assert.NotNull(sut);
             Assert.Equal(10, sut.ScenarioStepPatterns.Count);
 
-            AssertPattern(0, PatternKind.Given, "something");
-            AssertPattern(1, PatternKind.Given, "something else");
-            AssertPattern(2, PatternKind.And, "something");
-            AssertPattern(3, PatternKind.And, "something else");
-            AssertPattern(4, PatternKind.When, "something");
-            AssertPattern(5, PatternKind.When, "something else");
-            AssertPattern(6, PatternKind.And, "something");
-            AssertPattern(7, PatternKind.And, "something else");
-            AssertPattern(8, PatternKind.But, "something");
-            AssertPattern(9, PatternKind.But, "something else");
+            AssertPattern(0, GherkinDialect.KeywordFor.Given, "something");
+            AssertPattern(1, GherkinDialect.KeywordFor.Given, "something else");
+            AssertPattern(2, GherkinDialect.KeywordFor.And, "something");
+            AssertPattern(3, GherkinDialect.KeywordFor.And, "something else");
+            AssertPattern(4, GherkinDialect.KeywordFor.When, "something");
+            AssertPattern(5, GherkinDialect.KeywordFor.When, "something else");
+            AssertPattern(6, GherkinDialect.KeywordFor.And, "something");
+            AssertPattern(7, GherkinDialect.KeywordFor.And, "something else");
+            AssertPattern(8, GherkinDialect.KeywordFor.But, "something");
+            AssertPattern(9, GherkinDialect.KeywordFor.But, "something else");
 
-            void AssertPattern(int index, PatternKind patternKind, string pattern)
+            void AssertPattern(int index, GherkinDialect.KeywordFor patternKind, string pattern)
             {
                 var thePattern = sut.ScenarioStepPatterns[index];
 
@@ -430,7 +430,7 @@ in it";
 
             //assert.
             Assert.NotNull(match);
-            Assert.Equal(PatternKind.When, match.Kind);
+            Assert.Equal(GherkinDialect.KeywordFor.When, match.Kind);
             Assert.Equal("this matches", match.OriginalPattern);
         }
 

--- a/source/Xunit.Gherkin.Quick.UnitTests/StepMethodKindExtensionsTests.cs
+++ b/source/Xunit.Gherkin.Quick.UnitTests/StepMethodKindExtensionsTests.cs
@@ -14,27 +14,27 @@ namespace UnitTests
                     new object[]
                     {
                         new GivenAttribute("123"),
-                        PatternKind.Given
+                        GherkinDialect.KeywordFor.Given
                     },
                     new object[]
                     {
                         new WhenAttribute("123"),
-                        PatternKind.When
+                        GherkinDialect.KeywordFor.When
                     },
                     new object[]
                     {
                         new ThenAttribute("123"),
-                        PatternKind.Then
+                        GherkinDialect.KeywordFor.Then
                     },
                     new object[]
                     {
                         new AndAttribute("123"),
-                        PatternKind.And
+                        GherkinDialect.KeywordFor.And
                     },
                     new object[]
                     {
                         new ButAttribute("123"),
-                        PatternKind.But
+                        GherkinDialect.KeywordFor.But
                     }
                 };
             }
@@ -44,7 +44,7 @@ namespace UnitTests
         [MemberData(nameof(AllStepDefinitionAttributes))]
         internal void ToStepMethodKind_Converts_based_on_Attribute_type(
             BaseStepDefinitionAttribute attribute,
-            PatternKind kind
+            GherkinDialect.KeywordFor kind
             )
         {
             //act.
@@ -55,25 +55,25 @@ namespace UnitTests
         }
 
         [Theory]
-        [InlineData(PatternKind.Given, "Given", true)]
-        [InlineData(PatternKind.Given, "And", false)]
-        [InlineData(PatternKind.Given, "*", true)]
-        [InlineData(PatternKind.When, "When", true)]
-        [InlineData(PatternKind.When, "Given", false)]
-        [InlineData(PatternKind.When, "*", true)]
-        [InlineData(PatternKind.Then, "Then", true)]
-        [InlineData(PatternKind.Then, "But", false)]
-        [InlineData(PatternKind.Then, "*", true)]
-        [InlineData(PatternKind.And, "And", true)]
-        [InlineData(PatternKind.And, "Given", false)]
-        [InlineData(PatternKind.And, "*", true)]
+        [InlineData(GherkinDialect.KeywordFor.Given, "Given", true)]
+        [InlineData(GherkinDialect.KeywordFor.Given, "And", false)]
+        [InlineData(GherkinDialect.KeywordFor.Given, "*", true)]
+        [InlineData(GherkinDialect.KeywordFor.When, "When", true)]
+        [InlineData(GherkinDialect.KeywordFor.When, "Given", false)]
+        [InlineData(GherkinDialect.KeywordFor.When, "*", true)]
+        [InlineData(GherkinDialect.KeywordFor.Then, "Then", true)]
+        [InlineData(GherkinDialect.KeywordFor.Then, "But", false)]
+        [InlineData(GherkinDialect.KeywordFor.Then, "*", true)]
+        [InlineData(GherkinDialect.KeywordFor.And, "And", true)]
+        [InlineData(GherkinDialect.KeywordFor.And, "Given", false)]
+        [InlineData(GherkinDialect.KeywordFor.And, "*", true)]
         internal void Match_Is_Comparing_With_String_Keyword(
-            PatternKind patternKind,
+            GherkinDialect.KeywordFor patternKind,
             string keyword,
             bool expectedMatch)
         {
             //act.
-            var actualMatch = patternKind.Matches(keyword);
+            var actualMatch = patternKind.CouldBe(keyword);
 
             //assert.
             Assert.Equal(expectedMatch, actualMatch);

--- a/source/Xunit.Gherkin.Quick/CoreModel/Feature/FeatureClass.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Feature/FeatureClass.cs
@@ -48,7 +48,7 @@ namespace Xunit.Gherkin.Quick
 			return new Scenario(steps);
 		}
 
-		private List<StepMethod> ExtractSteps(global::Gherkin.Ast.ScenarioDefinition gherkinScenario)
+		private List<StepMethod> ExtractSteps(global::Gherkin.Ast.StepsContainer gherkinScenario)
         {
             if (gherkinScenario == null)
                 throw new ArgumentNullException(nameof(gherkinScenario));

--- a/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioDiscoverer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit.Abstractions;
+
 using Xunit.Sdk;
 
 namespace Xunit.Gherkin.Quick
@@ -31,7 +32,7 @@ namespace Xunit.Gherkin.Quick
 
             foreach (var feature in features)
             {
-                foreach (var scenario in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
+                foreach (var scenario in feature.Scenarios())
                 {
                     var tags = feature.GetScenarioTags(scenario.Name);
                     bool skip = feature.IsScenarioIgnored(scenario.Name);

--- a/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioOutlineDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioOutlineDiscoverer.cs
@@ -28,7 +28,7 @@ namespace Xunit.Gherkin.Quick
 
             foreach (var feature in features)
             {
-                foreach (var scenarioOutline in feature.Children.OfType<ScenarioOutline>())
+                foreach (var scenarioOutline in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
                 {
                     foreach (var example in scenarioOutline.Examples)
                     {

--- a/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioOutlineDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Feature/MissingFeature/MissingScenarioOutlineDiscoverer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Abstractions;
+
 using Xunit.Sdk;
 
 namespace Xunit.Gherkin.Quick
@@ -28,7 +29,7 @@ namespace Xunit.Gherkin.Quick
 
             foreach (var feature in features)
             {
-                foreach (var scenarioOutline in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
+                foreach (var scenarioOutline in feature.Outlines())
                 {
                     foreach (var example in scenarioOutline.Examples)
                     {

--- a/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
@@ -19,7 +19,7 @@ namespace Xunit.Gherkin.Quick
         {
             GherkinDocument = gherkinDocument ?? throw new System.ArgumentNullException(nameof(gherkinDocument));
 
-            if (StepMethodInfo.Dialects.Any(d => d.Language == GherkinDocument.Feature.Language) is false)
+            if (StepMethodInfo.Dialects.Any(d => d.Language == (GherkinDocument.Feature.Language ?? StepMethodInfo.GherkingDialectProvider.DefaultDialect.Language)) is false)
                 StepMethodInfo.Dialects.Add(StepMethodInfo.GherkingDialectProvider.GetDialect(GherkinDocument.Feature.Language, GherkinDocument.Feature.Location));
         }
 

--- a/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
@@ -1,6 +1,10 @@
 ﻿using Gherkin.Ast;
 using System.Linq;
 
+using Scenario = global::Gherkin.Ast.Scenario;
+using Background = global::Gherkin.Ast.Background;
+using StepsContainer = Gherkin.Ast.StepsContainer;
+
 namespace Xunit.Gherkin.Quick
 {
     internal sealed class FeatureFile
@@ -14,7 +18,10 @@ namespace Xunit.Gherkin.Quick
 
         public global::Gherkin.Ast.Scenario GetScenario(string scenarioName)
         {
-            return GherkinDocument.Feature.Children.FirstOrDefault(s => s.Name == scenarioName) as global::Gherkin.Ast.Scenario;
+
+            return GherkinDocument.Feature.Children.FirstOrDefault(c => (c as global::Gherkin.Ast.Scenario)?.Name == scenarioName) as global::Gherkin.Ast.Scenario;
+
+            //return GherkinDocument.Feature.Children.FirstOrDefault(s => s.Name == scenarioName) as global::Gherkin.Ast.Scenario;
         }
 
 		public global::Gherkin.Ast.Background GetBackground()
@@ -22,9 +29,11 @@ namespace Xunit.Gherkin.Quick
 			return GherkinDocument.Feature.Children.OfType<global::Gherkin.Ast.Background>().SingleOrDefault();
 		}
 
-        internal ScenarioOutline GetScenarioOutline(string scenarioOutlineName)
+        internal global::Gherkin.Ast.Scenario GetScenarioOutline(string scenarioOutlineName)
         {
-            return GherkinDocument.Feature.Children.FirstOrDefault(s => s.Name == scenarioOutlineName) as global::Gherkin.Ast.ScenarioOutline;
+
+            return GherkinDocument.Feature.Children.FirstOrDefault(c => (c as global::Gherkin.Ast.Scenario)?.Name == scenarioOutlineName) as global::Gherkin.Ast.Scenario;
+            //return GherkinDocument.Feature.Children.FirstOrDefault(s => (s as StepsContainer)?.Name == scenarioOutlineName) as global::Gherkin.Ast.StepsContainer;
         }
     }
 }

--- a/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
@@ -1,4 +1,7 @@
-﻿using Gherkin.Ast;
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Gherkin.Ast;
 using System.Linq;
 
 using Scenario = global::Gherkin.Ast.Scenario;
@@ -9,11 +12,15 @@ namespace Xunit.Gherkin.Quick
 {
     internal sealed class FeatureFile
     {
+        
         public GherkinDocument GherkinDocument { get; }
 
         public FeatureFile(GherkinDocument gherkinDocument)
         {
             GherkinDocument = gherkinDocument ?? throw new System.ArgumentNullException(nameof(gherkinDocument));
+
+            if (StepMethodInfo.Dialects.Any(d => d.Language == GherkinDocument.Feature.Language) is false)
+                StepMethodInfo.Dialects.Add(StepMethodInfo.GherkingDialectProvider.GetDialect(GherkinDocument.Feature.Language, GherkinDocument.Feature.Location));
         }
 
         public global::Gherkin.Ast.Scenario GetScenario(string scenarioName)

--- a/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
@@ -19,17 +19,14 @@ namespace Xunit.Gherkin.Quick
         {
             GherkinDocument = gherkinDocument ?? throw new System.ArgumentNullException(nameof(gherkinDocument));
 
-            if (StepMethodInfo.Dialects.Any(d => d.Language == (GherkinDocument.Feature?.Language ?? StepMethodInfo.GherkingDialectProvider.DefaultDialect.Language)) is false)
-                StepMethodInfo.Dialects.Add(StepMethodInfo.GherkingDialectProvider.GetDialect(GherkinDocument.Feature.Language, GherkinDocument.Feature.Location));
+            GherkinDialect.Register(
+                GherkinDocument.Feature?.Language,
+                GherkinDocument.Feature?.Location
+            );
         }
 
         public global::Gherkin.Ast.Scenario GetScenario(string scenarioName)
-        {
-
-            return GherkinDocument.Feature.Children.FirstOrDefault(c => (c as global::Gherkin.Ast.Scenario)?.Name == scenarioName) as global::Gherkin.Ast.Scenario;
-
-            //return GherkinDocument.Feature.Children.FirstOrDefault(s => s.Name == scenarioName) as global::Gherkin.Ast.Scenario;
-        }
+            => GherkinDocument.Feature.Scenarios().Where(s => s.Name == scenarioName).FirstOrDefault();
 
 		public global::Gherkin.Ast.Background GetBackground()
 		{
@@ -37,10 +34,7 @@ namespace Xunit.Gherkin.Quick
 		}
 
         internal global::Gherkin.Ast.Scenario GetScenarioOutline(string scenarioOutlineName)
-        {
+            => GherkinDocument.Feature.Outlines().Where(s => s.Name == scenarioOutlineName).FirstOrDefault();
 
-            return GherkinDocument.Feature.Children.FirstOrDefault(c => (c as global::Gherkin.Ast.Scenario)?.Name == scenarioOutlineName) as global::Gherkin.Ast.Scenario;
-            //return GherkinDocument.Feature.Children.FirstOrDefault(s => (s as StepsContainer)?.Name == scenarioOutlineName) as global::Gherkin.Ast.StepsContainer;
-        }
     }
 }

--- a/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/FeatureFile/FeatureFile.cs
@@ -19,7 +19,7 @@ namespace Xunit.Gherkin.Quick
         {
             GherkinDocument = gherkinDocument ?? throw new System.ArgumentNullException(nameof(gherkinDocument));
 
-            if (StepMethodInfo.Dialects.Any(d => d.Language == (GherkinDocument.Feature.Language ?? StepMethodInfo.GherkingDialectProvider.DefaultDialect.Language)) is false)
+            if (StepMethodInfo.Dialects.Any(d => d.Language == (GherkinDocument.Feature?.Language ?? StepMethodInfo.GherkingDialectProvider.DefaultDialect.Language)) is false)
                 StepMethodInfo.Dialects.Add(StepMethodInfo.GherkingDialectProvider.GetDialect(GherkinDocument.Feature.Language, GherkinDocument.Feature.Location));
         }
 

--- a/source/Xunit.Gherkin.Quick/CoreModel/GherkinDialect.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/GherkinDialect.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Xunit.Gherkin.Quick
+{
+    using Gherkin = global::Gherkin;
+    using Ast = global::Gherkin.Ast;
+
+    internal static partial class GherkinDialect
+    {
+        private static Gherkin.GherkinDialectProvider GherkingDialectProvider { get;  } = new();
+
+        private static Dictionary<string, Gherkin.GherkinDialect> Dialects { get; } = new() 
+            {{ GherkingDialectProvider.DefaultDialect.Language, GherkingDialectProvider.DefaultDialect }};
+
+        public static void Register(string? language, Gherkin.Ast.Location? location)
+        {
+            if (language is null || location is null) return;
+
+            if (Dialects.Keys.Contains(language)) return;
+            
+            Dialects[language] = GherkingDialectProvider.GetDialect(language, location);
+
+        }
+
+        private static IEnumerable<string> Keywords(this IEnumerable<Gherkin.GherkinDialect> @this, Func<Gherkin.GherkinDialect, string[]> keywords)
+            => Enumerable.Distinct(
+                @this.SelectMany(
+                    dialect => Enumerable.Concat(
+                        from k in keywords(dialect) select k,
+                        from k in keywords(dialect) select k.Trim()
+                    )
+                )
+            );
+
+        public enum KeywordFor
+        {
+            Feature, Background, Rule, Scenario, Outline,
+
+            Examples,
+
+            Given, When, Then, And, But
+        }
+        
+        public static bool CouldBe(this KeywordFor @for, string keyword)
+            => @for switch
+            {
+                KeywordFor.Feature => Dialects.Values.Keywords(d => d.FeatureKeywords).Contains(keyword),
+                KeywordFor.Background => Dialects.Values.Keywords(d => d.BackgroundKeywords).Contains(keyword),
+                KeywordFor.Rule => Dialects.Values.Keywords(d => d.RuleKeywords).Contains(keyword),
+                KeywordFor.Scenario => Dialects.Values.Keywords(d => d.ScenarioKeywords).Contains(keyword),
+                KeywordFor.Outline => Dialects.Values.Keywords(d => d.ScenarioOutlineKeywords).Contains(keyword),
+                KeywordFor.Examples => Dialects.Values.Keywords(d => d.ExamplesKeywords).Contains(keyword),
+                KeywordFor.Given => Dialects.Values.Keywords(d => d.GivenStepKeywords).Contains(keyword),
+                KeywordFor.When => Dialects.Values.Keywords(d => d.WhenStepKeywords).Contains(keyword),
+                KeywordFor.Then => Dialects.Values.Keywords(d => d.ThenStepKeywords).Contains(keyword),
+                KeywordFor.And => Dialects.Values.Keywords(d => d.AndStepKeywords).Contains(keyword),
+                KeywordFor.But => Dialects.Values.Keywords(d => d.ButStepKeywords).Contains(keyword)
+            };
+
+        public static bool IsScenario(this Ast.Scenario @this)
+            => KeywordFor.Scenario.CouldBe(@this.Keyword);
+
+        public static bool IsOutline(this Ast.Scenario @this)
+            => KeywordFor.Outline.CouldBe(@this.Keyword);
+
+    }
+}

--- a/source/Xunit.Gherkin.Quick/CoreModel/GherkinFeatureExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/GherkinFeatureExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Ast = global::Gherkin.Ast;
+
+namespace Xunit.Gherkin.Quick
+{
+    internal static partial class GherkinFeatureExtensions
+    {
+        public static IEnumerable<Ast.Scenario> Scenarios(this Ast.Feature @this) 
+            => @this.Children.OfType<Ast.Scenario>().Where(s => s.IsScenario());
+
+        public static IEnumerable<Ast.Scenario> Outlines(this Ast.Feature @this) 
+            => @this.Children.OfType<Ast.Scenario>().Where(s => s.IsOutline());
+    }
+}

--- a/source/Xunit.Gherkin.Quick/CoreModel/GherkinScenarioExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/GherkinScenarioExtensions.cs
@@ -15,12 +15,14 @@ namespace Xunit.Gherkin.Quick
             var stepsWithBackground = background.Steps.Concat(@this.Steps).ToArray();
 
             return new global::Gherkin.Ast.Scenario(
-                @this.Tags.ToArray(), 
-                @this.Location, 
-                @this.Keyword, 
-                @this.Name, 
-                @this.Description, 
-                stepsWithBackground);
+                @this.Tags.ToArray(),
+                @this.Location,
+                @this.Keyword,
+                @this.Name,
+                @this.Description,
+                stepsWithBackground,
+                Array.Empty<global::Gherkin.Ast.Examples>()
+            );
         }       
     }
 }

--- a/source/Xunit.Gherkin.Quick/CoreModel/GherkinScenarioOutlineExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/GherkinScenarioOutlineExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Gherkin.Ast;
 using DataTable = Gherkin.Ast.DataTable;
 using TableRow = Gherkin.Ast.TableRow;
 using TableCell = Gherkin.Ast.TableCell;
@@ -14,7 +15,7 @@ namespace Xunit.Gherkin.Quick
         private static readonly Regex _placeholderRegex = new Regex(@"<([^>]+)>");
 
         public static global::Gherkin.Ast.Scenario ApplyExampleRow(
-            this global::Gherkin.Ast.ScenarioOutline @this,
+            this global::Gherkin.Ast.Scenario @this,
             string exampleName,
             int exampleRowIndex)
         {
@@ -45,10 +46,12 @@ namespace Xunit.Gherkin.Quick
                 @this.Keyword,
                 @this.Name,
                 @this.Description,
-                scenarioSteps.ToArray());
+                scenarioSteps.ToArray(),
+                Array.Empty<Examples>()
+            );
         }
 
-        private static global::Gherkin.Ast.Step DigestExampleValuesIntoStep(global::Gherkin.Ast.ScenarioOutline @this, string exampleName, int exampleRowIndex, Dictionary<string, string> rowValues, global::Gherkin.Ast.Step outlineStep)
+        private static global::Gherkin.Ast.Step DigestExampleValuesIntoStep(global::Gherkin.Ast.StepsContainer @this, string exampleName, int exampleRowIndex, Dictionary<string, string> rowValues, global::Gherkin.Ast.Step outlineStep)
         {
             string matchEvaluator(Match match)
             {
@@ -109,7 +112,7 @@ namespace Xunit.Gherkin.Quick
             return rowValues;
         }
 
-        private static List<global::Gherkin.Ast.TableCell> GetExampleRow(global::Gherkin.Ast.ScenarioOutline @this, int exampleRowIndex, global::Gherkin.Ast.Examples examples)
+        private static List<global::Gherkin.Ast.TableCell> GetExampleRow(global::Gherkin.Ast.StepsContainer @this, int exampleRowIndex, global::Gherkin.Ast.Examples examples)
         {
             var exampleRows = examples.TableBody.ToList();
             if (!(exampleRowIndex < exampleRows.Count))

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/ScenarioStepPattern.cs
@@ -19,9 +19,9 @@ namespace Xunit.Gherkin.Quick
         /// </summary>
         public string RegexPattern { get { return _regexPattern; } }
 
-        public PatternKind Kind { get; }
+        public GherkinDialect.KeywordFor Kind { get; }
 
-        public ScenarioStepPattern(string pattern, string regexPattern, PatternKind stepMethodKind)
+        public ScenarioStepPattern(string pattern, string regexPattern, GherkinDialect.KeywordFor stepMethodKind)
         {
             _originalPattern = !string.IsNullOrWhiteSpace(pattern) 
                 ? pattern 

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethod.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethod.cs
@@ -11,11 +11,11 @@ namespace Xunit.Gherkin.Quick
 
         public string StepText { get; }
 
-        public PatternKind Kind { get; }
+        public GherkinDialect.KeywordFor Kind { get; }
 
         public string Pattern { get; }
 
-        private StepMethod(StepMethodInfo stepMethodInfo, PatternKind kind, string pattern, string stepText)
+        private StepMethod(StepMethodInfo stepMethodInfo, GherkinDialect.KeywordFor kind, string pattern, string stepText)
         {
             _stepMethodInfo = stepMethodInfo ?? throw new ArgumentNullException(nameof(stepMethodInfo));
             Kind = kind;

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
@@ -11,6 +11,19 @@ namespace Xunit.Gherkin.Quick
 {
     internal sealed class StepMethodInfo
     {
+        internal static global::Gherkin.GherkinDialectProvider GherkingDialectProvider { get;  } = new();
+
+        internal static List<global::Gherkin.GherkinDialect> Dialects { get; } = new[] {GherkingDialectProvider.DefaultDialect}.ToList();
+
+        internal static bool PatternKindAndKeywordMatch(PatternKind pattern, string keyword) => pattern switch
+        {
+            PatternKind.Given => Dialects.Any(d => d.GivenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
+            PatternKind.And => Dialects.Any(d => d.AndStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
+            PatternKind.When => Dialects.Any(d => d.WhenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
+            PatternKind.Then => Dialects.Any(d => d.ThenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
+            PatternKind.But => Dialects.Any(d => d.ButStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase))
+        };
+
         public ReadOnlyCollection<ScenarioStepPattern> ScenarioStepPatterns { get; }
 
         private readonly ReadOnlyCollection<StepMethodArgument> _arguments;
@@ -171,11 +184,7 @@ namespace Xunit.Gherkin.Quick
         }
 
         public static bool Matches(this PatternKind patternKind, string keyword)
-        {
-            if (keyword == "*")
-                return true;
+            => StepMethodInfo.PatternKindAndKeywordMatch(patternKind, keyword);
 
-            return patternKind.ToString().Equals(keyword, StringComparison.OrdinalIgnoreCase);
-        }
     }
 }

--- a/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/StepMethod/StepMethodInfo.cs
@@ -11,19 +11,6 @@ namespace Xunit.Gherkin.Quick
 {
     internal sealed class StepMethodInfo
     {
-        internal static global::Gherkin.GherkinDialectProvider GherkingDialectProvider { get;  } = new();
-
-        internal static List<global::Gherkin.GherkinDialect> Dialects { get; } = new[] {GherkingDialectProvider.DefaultDialect}.ToList();
-
-        internal static bool PatternKindAndKeywordMatch(PatternKind pattern, string keyword) => pattern switch
-        {
-            PatternKind.Given => Dialects.Any(d => d.GivenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
-            PatternKind.And => Dialects.Any(d => d.AndStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
-            PatternKind.When => Dialects.Any(d => d.WhenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
-            PatternKind.Then => Dialects.Any(d => d.ThenStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase)),
-            PatternKind.But => Dialects.Any(d => d.ButStepKeywords.Select(k => k.Trim()).Contains(keyword, StringComparer.OrdinalIgnoreCase))
-        };
-
         public ReadOnlyCollection<ScenarioStepPattern> ScenarioStepPatterns { get; }
 
         private readonly ReadOnlyCollection<StepMethodArgument> _arguments;
@@ -145,18 +132,9 @@ namespace Xunit.Gherkin.Quick
         }
     }
 
-    internal enum PatternKind
-    {
-        Given,
-        When,
-        Then,
-        And,
-        But
-    }
-
     internal static class PatternKindExtensions
     {
-        public static PatternKind ToPatternKind(BaseStepDefinitionAttribute @this)
+        public static GherkinDialect.KeywordFor ToPatternKind(BaseStepDefinitionAttribute @this)
         {
             if (@this == null)
                 throw new ArgumentNullException(nameof(@this));
@@ -164,27 +142,27 @@ namespace Xunit.Gherkin.Quick
             switch (@this)
             {
                 case GivenAttribute _:
-                    return PatternKind.Given;
+                    return GherkinDialect.KeywordFor.Given;
 
                 case WhenAttribute _:
-                    return PatternKind.When;
+                    return GherkinDialect.KeywordFor.When;
 
                 case ThenAttribute _:
-                    return PatternKind.Then;
+                    return GherkinDialect.KeywordFor.Then;
 
                 case AndAttribute _:
-                    return PatternKind.And;
+                    return GherkinDialect.KeywordFor.And;
 
                 case ButAttribute _:
-                    return PatternKind.But;
+                    return GherkinDialect.KeywordFor.But;
 
                 default:
                     throw new NotSupportedException($"Cannot convert into step method kind: Attribute type {@this.GetType()} is not supported.");
             }
         }
 
-        public static bool Matches(this PatternKind patternKind, string keyword)
-            => StepMethodInfo.PatternKindAndKeywordMatch(patternKind, keyword);
+        public static bool Matches(this GherkinDialect.KeywordFor patternKind, string keyword)
+            => patternKind.CouldBe(keyword);
 
     }
 }

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/GherkinFeatureExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/GherkinFeatureExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Xunit.Gherkin.Quick
 {
-    internal static class GherkinFeatureExtensions
+    internal static partial class GherkinFeatureExtensions
     {
         public static List<string> GetScenarioTags(
             this global::Gherkin.Ast.Feature feature,
@@ -16,10 +16,7 @@ namespace Xunit.Gherkin.Quick
             if (string.IsNullOrWhiteSpace(scenarioName))
                 throw new ArgumentNullException(nameof(scenarioName));
 
-            var scenario = feature
-                .Children
-                .OfType<global::Gherkin.Ast.Scenario>()
-                .FirstOrDefault(s => s.Name == scenarioName);
+            var scenario = feature.Scenarios().FirstOrDefault(s => s.Name == scenarioName);
 
             if (scenario == null)
                 throw new InvalidOperationException($"Cannot find scenario `{scenarioName}` under feature `{feature.Name}`.");
@@ -53,8 +50,7 @@ namespace Xunit.Gherkin.Quick
             if (string.IsNullOrWhiteSpace(scenarioOutlineName))
                 throw new ArgumentNullException(nameof(scenarioOutlineName));
             
-            var scenarioOutline = feature.Children.OfType<global::Gherkin.Ast.Scenario>()
-                .FirstOrDefault(o => o.Name == scenarioOutlineName);
+            var scenarioOutline = feature.Outlines().FirstOrDefault(o => o.Name == scenarioOutlineName);
 
             if (scenarioOutline == null)
                 throw new InvalidOperationException($"Cannot find scenario outline `{scenarioOutlineName}` under feature `{feature.Name}`.");

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/GherkinFeatureExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/GherkinFeatureExtensions.cs
@@ -53,7 +53,7 @@ namespace Xunit.Gherkin.Quick
             if (string.IsNullOrWhiteSpace(scenarioOutlineName))
                 throw new ArgumentNullException(nameof(scenarioOutlineName));
             
-            var scenarioOutline = feature.Children.OfType<global::Gherkin.Ast.ScenarioOutline>()
+            var scenarioOutline = feature.Children.OfType<global::Gherkin.Ast.Scenario>()
                 .FirstOrDefault(o => o.Name == scenarioOutlineName);
 
             if (scenarioOutline == null)

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/ScenarioDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/ScenarioDiscoverer.cs
@@ -23,6 +23,9 @@ namespace Xunit.Gherkin.Quick
 
             foreach (var scenario in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
             {
+                if (scenario.Examples.Any())
+                    continue;
+
                 var tags = feature.GetScenarioTags(scenario.Name);
                 bool skip = feature.IsScenarioIgnored(scenario.Name);
 

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/ScenarioDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/Scenario/ScenarioDiscoverer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;
+
 using Xunit.Sdk;
 
 namespace Xunit.Gherkin.Quick
@@ -21,11 +22,8 @@ namespace Xunit.Gherkin.Quick
         {
             var feature = new FeatureDiscoveryModel(new FeatureFileRepository("*.feature")).Discover(testMethod.TestClass.Class.ToRuntimeType());
 
-            foreach (var scenario in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
+            foreach (var scenario in feature.Scenarios())
             {
-                if (scenario.Examples.Any())
-                    continue;
-
                 var tags = feature.GetScenarioTags(scenario.Name);
                 bool skip = feature.IsScenarioIgnored(scenario.Name);
 

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioOutline/ScenarioOutlineDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioOutline/ScenarioOutlineDiscoverer.cs
@@ -22,7 +22,7 @@ namespace Xunit.Gherkin.Quick
         {
             var feature = new FeatureDiscoveryModel(new FeatureFileRepository("*.feature")).Discover(testMethod.TestClass.Class.ToRuntimeType());
 
-            foreach (var scenarioOutline in feature.Children.OfType<ScenarioOutline>())
+            foreach (var scenarioOutline in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
             {
                 foreach (var example in scenarioOutline.Examples)
                 {

--- a/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioOutline/ScenarioOutlineDiscoverer.cs
+++ b/source/Xunit.Gherkin.Quick/ScenarioXunitHook/ScenarioOutline/ScenarioOutlineDiscoverer.cs
@@ -22,7 +22,7 @@ namespace Xunit.Gherkin.Quick
         {
             var feature = new FeatureDiscoveryModel(new FeatureFileRepository("*.feature")).Discover(testMethod.TestClass.Class.ToRuntimeType());
 
-            foreach (var scenarioOutline in feature.Children.OfType<global::Gherkin.Ast.Scenario>())
+            foreach (var scenarioOutline in feature.Outlines())
             {
                 foreach (var example in scenarioOutline.Examples)
                 {

--- a/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
+++ b/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>Xunit.Gherkin.Quick</PackageId>
     <Title>Xunit.Gherkin.Quick</Title>
@@ -19,10 +19,11 @@
     <PackageReleaseNotes>https://github.com/ttutisani/Xunit.Gherkin.Quick/blob/master/versions/4.2.0.md</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gherkin" Version="5.0.0" />
+    <PackageReference Include="gherkin" Version="23.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
* Gherkin was updated
* All the projects now target .NET Standard 2.0
* Gherkin tests in other languages are now possible

Before changing this I want to add a few more tests in emoji-lang to exercise all keywords (examples, rules, etc).

Stuff I've noticed and would like to address:
* Not all files are consistent with indenting (some are tabbed, some are spaces, some are mixed)
* Not all files have the same line endings
* The unit test project has a `GherkinFeatureBuilder` which isn't used consistently