### PR TITLE
Add scenario outlines' examples insertions inside the DocString's content.

### DIFF
--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
@@ -10,18 +10,18 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
         private DocString _stringData;
 
         [Given("I have supplied a DataTable with")]
-        public void I_Have_Supplied_DataTable(DataTable data)
+        public void Given_I_Have_Supplied_DataTable(DataTable data)
         {
             _tableData = data;
         }
 
         [When("I execute a scenario outline")]
-        public void I_Execute_A_Scenario_Outline()
+        public void When_I_Execute_A_Scenario_Outline()
         {
         }
 
         [Then(@"the DataTables MealExtra column should contain (\w+)")]
-        public void The_DataTables_MealExtra_Column_Should_Contain(string fruit)
+        public void Then_the_DataTables_MealExtra_Column_Should_Contain(string fruit)
         {
             Assert.NotNull(_tableData);
             var dataRow = _tableData.Rows.Skip(1).FirstOrDefault();
@@ -30,13 +30,13 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
         }
 
         [Given("I have supplied a DocString with")]
-        public void I_have_supplied_a_docstring_with(DocString data)
+        public void Given_I_Have_Supplied_A_DocString_With(DocString data)
         {
             _stringData = data;
         }
 
         [Then(@"the DocString should contain a {} plan for {} for {} plus {} portions and {} extra, containing {}, an optional hot drink {} {} and a description for a smoothie of a {} and {} combo")]
-        public void The_docstring_should_contain(
+        public void Then_The_DocString_Should_Contain(
             string meal, string date, int myPortions, int otherPortions, int provision, string mainDish, string needHotDrink, string hotDrink, string fruit, string addition)
         {
             Assert.NotNull(_stringData);
@@ -50,7 +50,7 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
 The main dish for {date} is: {mainDish}!
 Additionally prepare a {fruit}-based smoothie with some {addition}.
 Optionally add a cup of hot {hotDrink}? {needHotDrink}.
-Total portions needed: {myPortions}+{otherPortions}+{provision}! ";
+Total portions needed: {myPortions}+{otherPortions}+{provision}!";
 
             Assert.Equal(expectedContent, dataContent);
         }

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
@@ -1,4 +1,5 @@
 ﻿using Gherkin.Ast;
+using System;
 using System.Linq;
 
 namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
@@ -46,11 +47,7 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
             Assert.DoesNotContain('<', dataContent);
             Assert.DoesNotContain('>', dataContent);
 
-            var expectedContent = $@"{date} Delicious {meal} plan:
-The main dish for {date} is: {mainDish}!
-Additionally prepare a {fruit}-based smoothie with some {addition}.
-Optionally add a cup of hot {hotDrink}? {needHotDrink}.
-Total portions needed: {myPortions}+{otherPortions}+{provision}!";
+            var expectedContent = $@"{date} Delicious {meal} plan:{Environment.NewLine}The main dish for {date} is: {mainDish}!{Environment.NewLine}Additionally prepare a {fruit}-based smoothie with some {addition}.{Environment.NewLine}Optionally add a cup of hot {hotDrink}? {needHotDrink}.{Environment.NewLine}Total portions needed: {myPortions}+{otherPortions}+{provision}!";
 
             Assert.Equal(expectedContent, dataContent);
         }

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
@@ -1,4 +1,5 @@
 ﻿using Gherkin.Ast;
+using System;
 using System.Linq;
 
 namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
@@ -6,26 +7,53 @@ namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders
     [FeatureFile("./Placeholders/Placeholders.feature")]
     public sealed class Placeholder : Feature
     {
-        private DataTable _data;
+        private DataTable _tableData;
+        private DocString _stringData;
 
         [Given("I have supplied a DataTable with")]
-        public void Given_I_Have_Supplied_DataTable(DataTable data)
+        public void I_Have_Supplied_DataTable(DataTable data)
         {
-            _data = data;
+            _tableData = data;
         }
 
         [When("I execute a scenario outline")]
-        public void When_I_Execute_A_Scenario_Outline()
+        public void I_Execute_A_Scenario_Outline()
         {
         }
 
         [Then(@"the DataTables MealExtra column should contain (\w+)")]
-        public void Then_The_DataTables_MealExtra_Column_Should_Contain(string fruit)
+        public void The_DataTables_MealExtra_Column_Should_Contain(string fruit)
         {
-            Assert.NotNull(_data);
-            var dataRow = _data.Rows.Skip(1).FirstOrDefault();
+            Assert.NotNull(_tableData);
+            var dataRow = _tableData.Rows.Skip(1).FirstOrDefault();
             Assert.NotNull(dataRow);
             Assert.Equal(fruit, dataRow.Cells.FirstOrDefault()?.Value);
+        }
+
+        [Given("I have supplied a DocString with")]
+        public void I_have_supplied_a_docstring_with(DocString data)
+        {
+            _stringData = data;
+        }
+
+        [Then(@"the DocString should contain a {} plan for {} for {} plus {} portions and {} extra, containing {}, an optional hot drink {} {} and a description for a smoothie of a {} and {} combo")]
+        public void The_docstring_should_contain(
+            string meal, string date, int myPortions, int otherPortions, int provision, string mainDish, string needHotDrink, string hotDrink, string fruit, string addition)
+        {
+            Assert.NotNull(_stringData);
+            var dataContent = _stringData.Content;
+
+            Assert.NotNull(dataContent);
+            Assert.DoesNotContain('<', dataContent);
+            Assert.DoesNotContain('>', dataContent);
+
+            var expectedContent = $@"{date} Delicious {meal} plan:
+The main dish for {date} is: {mainDish}!
+Additionally prepare a {fruit}-based smoothie with some {addition}.
+Optionally add a cup of hot {hotDrink}? {needHotDrink}.
+Total portions needed: {myPortions}+{otherPortions}+{provision}! ";
+
+            Assert.Equal(expectedContent, dataContent);
         }
     }
 }

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.cs
@@ -1,5 +1,4 @@
 ﻿using Gherkin.Ast;
-using System;
 using System.Linq;
 
 namespace Xunit.Gherkin.Quick.ProjectConsumer.Placeholders

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
@@ -18,7 +18,7 @@ Scenario Outline: Placeholders in DocStrings are replaced
     The main dish for <Date> is: <MainDish>!
     Additionally prepare a <Fruit>-based smoothie with some <Addition>.
     Optionally add a cup of hot <HotDrink>? <HotDrinkNeeded>.
-    Total portions needed: <MyPortions>+<OtherPortions>+<Provision>! 
+    Total portions needed: <MyPortions>+<OtherPortions>+<Provision>!
     """
   When I execute a scenario outline
   Then the DocString should contain a <Meal> plan for <Date> for <MyPortions> plus <OtherPortions> portions and <Provision> extra, containing <MainDish>, an optional hot drink <HotDrinkNeeded> <HotDrink> and a description for a smoothie of a <Fruit> and <Addition> combo

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Placeholders/Placeholders.feature
@@ -10,3 +10,22 @@ Scenario Outline: Placeholders in DataTables are replaced
         | Fruit |
         | Apple |
         | Pear  |
+
+Scenario Outline: Placeholders in DocStrings are replaced
+  Given I have supplied a DocString with
+    """
+    <Date> Delicious <Meal> plan:
+    The main dish for <Date> is: <MainDish>!
+    Additionally prepare a <Fruit>-based smoothie with some <Addition>.
+    Optionally add a cup of hot <HotDrink>? <HotDrinkNeeded>.
+    Total portions needed: <MyPortions>+<OtherPortions>+<Provision>! 
+    """
+  When I execute a scenario outline
+  Then the DocString should contain a <Meal> plan for <Date> for <MyPortions> plus <OtherPortions> portions and <Provision> extra, containing <MainDish>, an optional hot drink <HotDrinkNeeded> <HotDrink> and a description for a smoothie of a <Fruit> and <Addition> combo
+  Examples:
+    | Date          | Meal      | MainDish            | HotDrinkNeeded | HotDrink | Fruit  | Addition | MyPortions | OtherPortions | Provision |
+    | 07.03.2024    | breakfast | omelette            | Yes            | coffee   | orange | mint     | 1          | 1             | 0         |
+    | 07.03.2024    | lunch     | steak               | No             | none     | pear   | cocoa    | 1          | 0             | 2         |
+    | 08.03.2024    | lunch     | omelette            | Yes            | tea      | apple  | mint     | 1          | 2             | 0         |
+    | Sundays       | breakfast | yogurt with berries | Yes            | coffee   | banana | protein  | 2          | 1             | 0         |
+    | any other day | breakfast | "french" omelette   | Yes            | tea      | orange | mint     | 1          | 1             | 1         |

--- a/source/Xunit.Gherkin.Quick/CoreModel/Scenario/GherkinScenarioOutlineExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Scenario/GherkinScenarioOutlineExtensions.cs
@@ -74,7 +74,7 @@ namespace Xunit.Gherkin.Quick
             return scenarioStep;
         }
 
-        private static global::Gherkin.Ast.StepArgument GetStepArgumentWithUpdatedText(global::Gherkin.Ast.Step outlineStep, MatchEvaluator textUpdater)
+        private static global::Gherkin.Ast.StepArgument GetStepArgumentWithUpdatedText(global::Gherkin.Ast.Step outlineStep, MatchEvaluator matchEvaluator)
         {
             var stepArgument = outlineStep.Argument;
 
@@ -93,7 +93,7 @@ namespace Xunit.Gherkin.Quick
                     }
                     else
                     {
-                        var digestedCells = row.Cells.Select(r => new TableCell(r.Location, _placeholderRegex.Replace(r.Value, textUpdater)));
+                        var digestedCells = row.Cells.Select(r => new TableCell(r.Location, _placeholderRegex.Replace(r.Value, matchEvaluator)));
                         digestedRows.Add(new TableRow(row.Location, digestedCells.ToArray()));
                     }
                 }
@@ -103,7 +103,7 @@ namespace Xunit.Gherkin.Quick
 
             if (stepArgument is DocString stepAsDocString)
             {
-                var updatedContent = _placeholderRegex.Replace(stepAsDocString.Content, textUpdater);
+                var updatedContent = _placeholderRegex.Replace(stepAsDocString.Content, matchEvaluator);
                 stepArgument = new DocString(stepAsDocString.Location, stepAsDocString.ContentType, updatedContent);
             }
 

--- a/source/Xunit.Gherkin.Quick/CoreModel/Scenario/GherkinScenarioOutlineExtensions.cs
+++ b/source/Xunit.Gherkin.Quick/CoreModel/Scenario/GherkinScenarioOutlineExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using DataTable = Gherkin.Ast.DataTable;
+using DocString = Gherkin.Ast.DocString;
 using TableRow = Gherkin.Ast.TableRow;
 using TableCell = Gherkin.Ast.TableCell;
 
@@ -63,15 +64,27 @@ namespace Xunit.Gherkin.Quick
 
             var stepText = _placeholderRegex.Replace(outlineStep.Text, matchEvaluator);
 
+            var stepArgument = GetStepArgumentWithUpdatedText(outlineStep, matchEvaluator);            
+
+            var scenarioStep = new global::Gherkin.Ast.Step(
+                outlineStep.Location,
+                outlineStep.Keyword,
+                stepText,
+                stepArgument);
+            return scenarioStep;
+        }
+
+        private static global::Gherkin.Ast.StepArgument GetStepArgumentWithUpdatedText(global::Gherkin.Ast.Step outlineStep, MatchEvaluator textUpdater)
+        {
             var stepArgument = outlineStep.Argument;
 
-            if (stepArgument is DataTable)
+            if (stepArgument is DataTable table)
             {
                 var processedHeaderRow = false;
 
                 var digestedRows = new List<TableRow>();
                 
-                foreach(var row in ((DataTable)stepArgument).Rows)
+                foreach (var row in table.Rows)
                 {
                     if (!processedHeaderRow)
                     {
@@ -80,7 +93,7 @@ namespace Xunit.Gherkin.Quick
                     }
                     else
                     {
-                        var digestedCells = row.Cells.Select(r => new TableCell(r.Location, _placeholderRegex.Replace(r.Value, matchEvaluator)));
+                        var digestedCells = row.Cells.Select(r => new TableCell(r.Location, _placeholderRegex.Replace(r.Value, textUpdater)));
                         digestedRows.Add(new TableRow(row.Location, digestedCells.ToArray()));
                     }
                 }
@@ -88,12 +101,13 @@ namespace Xunit.Gherkin.Quick
                 stepArgument = new DataTable(digestedRows.ToArray());
             }
 
-            var scenarioStep = new global::Gherkin.Ast.Step(
-                outlineStep.Location,
-                outlineStep.Keyword,
-                stepText,
-                stepArgument);
-            return scenarioStep;
+            if (stepArgument is DocString stepAsDocString)
+            {
+                var updatedContent = _placeholderRegex.Replace(stepAsDocString.Content, textUpdater);
+                stepArgument = new DocString(stepAsDocString.Location, stepAsDocString.ContentType, updatedContent);
+            }
+
+            return stepArgument;
         }
 
         private static Dictionary<string, string> GetExampleRowValues(global::Gherkin.Ast.Examples examples, List<global::Gherkin.Ast.TableCell> exampleRowCells)


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/ttutisani/Xunit.Gherkin.Quick/issues/145) by updating DocStrings' contents while running Scenario Outline tests based on the Examples table. 

Following[ this similar issue's solution](https://github.com/ttutisani/Xunit.Gherkin.Quick/issues/102), both a unit test and a behaviour test are added.