### PR TITLE
Version Bump & GitHub Actions Setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout Sources
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      run: dotnet test --no-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,13 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Restore
+      working-directory: source
       run: dotnet restore
 
     - name: Build
+      working-directory: source
       run: dotnet build --no-restore
 
     - name: Test
+      working-directory: source
       run: dotnet test --no-build

--- a/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
+++ b/source/Xunit.Gherkin.Quick.ProjectConsumer/Xunit.Gherkin.Quick.ProjectConsumer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,10 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Xunit.Gherkin.Quick.UnitTests/Xunit.Gherkin.Quick.UnitTests.csproj
+++ b/source/Xunit.Gherkin.Quick.UnitTests/Xunit.Gherkin.Quick.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
+++ b/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
     <PackageId>Xunit.Gherkin.Quick</PackageId>

--- a/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
+++ b/source/Xunit.Gherkin.Quick/Xunit.Gherkin.Quick.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
+    <IsTestProject>false</IsTestProject>
     <PackageId>Xunit.Gherkin.Quick</PackageId>
     <Title>Xunit.Gherkin.Quick</Title>
     <Description>BDD in .NET Core - Xunit.Gherkin.Quick is a lightweight, cross platform BDD test framework (targets .NET Standard, can be used from both .NET and .NET Core test projects). It parses Gherkin language and executes Xunit tests corresponding to scenarios.</Description>


### PR DESCRIPTION
Hi, I've noticed the test projects use an out of date dotnet framework and I've bumped the versions to latest LTS, I've also updated the xUnit packages.

I've also added a GitHub Actions workflow, I noticed this was an issue with the other PR wanting to do this (#123). There's no need to another dependency given that builds can be added to GitHub and require build status checks as part of the branch ruleset.

I've create a test branch on the fork demoing this, I've added the following check as part of the ruleset to enable it.

<img width="770" height="395" alt="image" src="https://github.com/user-attachments/assets/160499f8-a55a-4603-8bcd-860c42ab3212" />